### PR TITLE
Fix "TypeError: 'Request' object is not subscriptable" on Heroku.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python app.py
+web: pipenv run python app.py


### PR DESCRIPTION
The logviewer raised the following on my Heroku app:
```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/sanic/app.py", line 973, in handle_request
    response = await response
  File "app.py", line 53, in index
    return render_template("index")
  File "app.py", line 33, in render_template
    kwargs["session"] = request["session"]
TypeError: 'Request' object is not subscriptable
```
I just found out how to fix, so I made a pull request here.
