### PR TITLE
Remove skiplock from pipenv install step in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM library/python:latest
 RUN apt update && apt install -y pipenv
 RUN mkdir -p /bot && cd /bot && git clone https://github.com/kyb3r/logviewer .
 WORKDIR /bot
-RUN pipenv install --skip-lock
+RUN pipenv install
 
 CMD ["pipenv", "run", "python3", "app.py"]


### PR DESCRIPTION
This is needed so the versions locked with commit 3b689eb1deef5fd046edde185b9b7120c414334b are used.