### PR TITLE
Update runtime.txt

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.3
+python-3.7.9


### PR DESCRIPTION
use of python 3.7.9 so heroku stack-20 supports logviewer to work

python3.7.3 isnt available anymore for the default heroku stack ( stack-20 )