### PR TITLE
Avoiding usage of root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM library/python:latest
 RUN apt update && apt install -y pipenv
 RUN mkdir -p /bot && cd /bot && git clone https://github.com/kyb3r/logviewer .
 WORKDIR /bot
+
+RUN useradd -r -s /bin/false -m logviewer
+USER logviewer
+
 RUN pipenv install
 
 CMD ["pipenv", "run", "python3", "app.py"]


### PR DESCRIPTION
Hey there,

thank you so much for building and keeping this project maintained! Recently I moved my mod mail instance from Heroku to my host. With that, I closely reviewed how things do run. Something I noticed is that mod mail and log viewer do run as root. Running as a root especially a web application is something I personally would like to avoid. 

If there is a reason I did oversee for using root, I'm sorry, feel free to let me know! If not, could you please consider this pull request? 

This change might need future testing.

Thank you for your time and for keeping up this great project! 